### PR TITLE
Specify JSON schema of request body manually

### DIFF
--- a/src/test/routes/foo.ts
+++ b/src/test/routes/foo.ts
@@ -1,4 +1,4 @@
-import { Router, Get, PathParam, Middleware, Post, BodyParam } from '../../main';
+import { Router, Get, PathParam, Middleware, Post } from '../../main';
 
 export class FooRouter extends Router {
 
@@ -27,15 +27,20 @@ export class FooRouter extends Router {
 
     @Post({
         path: '/foo',
+        requestBodySchema: {
+            type: 'object',
+            properties: {
+                fooId: { type: 'string', minLength: 1 }
+            },
+            required: ['fooId']
+        },
         responses: {
             200: { contentType: 'text' }
         }
     })
-    async create(
-        @BodyParam('fooId', { required: true, schema: { type: 'string', minLength: 1 } })
-        fooId: string
-    ) {
+    async create() {
         this.ctx.status = 201;
+        const { fooId } = this.ctx.request.body;
         return { fooId };
     }
 

--- a/src/test/specs/router.test.ts
+++ b/src/test/specs/router.test.ts
@@ -152,7 +152,7 @@ describe('Router', () => {
             assert.equal(res.header['foo-before-all'], 'true');
             assert(res.header['bar-before-all'] == null);
             assert(res.header['foo-before-get-one'] == null);
-            assert.deepEqual(res.body.name, 'RequestParametersValidationError');
+            assert.deepEqual(res.body.name, 'RequestBodyValidationError');
         });
 
         it('POST /foo with incorrect params', async () => {
@@ -163,7 +163,7 @@ describe('Router', () => {
             assert.equal(res.header['foo-before-all'], 'true');
             assert(res.header['bar-before-all'] == null);
             assert(res.header['foo-before-get-one'] == null);
-            assert.deepEqual(res.body.name, 'RequestParametersValidationError');
+            assert.deepEqual(res.body.name, 'RequestBodyValidationError');
         });
 
         it('GET /foo/{fooId}', async () => {


### PR DESCRIPTION
Addresses part of https://ubio-automation.atlassian.net/browse/AC-148

See tests for how the consumer part changes.

IMO we still need to iterate on this change, to address [this](https://github.com/universalbasket/payment-broker/blob/48a09eef63c54b4eae0e3f7e384200204f93c70b/src/main/routes/test.ts#L19-L34) use case