### PR TITLE
feat: add BodyParam back to support both flavours

### DIFF
--- a/src/test/routes/foo.ts
+++ b/src/test/routes/foo.ts
@@ -1,4 +1,4 @@
-import { Router, Get, PathParam, Middleware, Post } from '../../main';
+import { Router, Get, PathParam, Middleware, Post, BodyParam, Put } from '../../main';
 
 export class FooRouter extends Router {
 
@@ -9,7 +9,7 @@ export class FooRouter extends Router {
 
     @Middleware({ path: '/foo/{fooId}' })
     async beforeGetOne(
-        @PathParam('fooId', { required: true, schema: { type: 'string' } })
+        @PathParam('fooId', { schema: { type: 'string' } })
         fooId: string
     ) {
         this.ctx.set('foo-before-get-one', fooId);
@@ -35,7 +35,7 @@ export class FooRouter extends Router {
             required: ['fooId']
         },
         responses: {
-            200: { contentType: 'text' }
+            200: { contentType: 'application/json' }
         }
     })
     async create() {
@@ -46,9 +46,24 @@ export class FooRouter extends Router {
 
     @Get({ path: '/foo/{fooId}' })
     async get(
-        @PathParam('fooId', { required: true, schema: { type: 'string' } })
+        @PathParam('fooId', { schema: { type: 'string' } })
         fooId: string
     ) {
         return { fooId };
+    }
+
+    @Put({
+        path: '/foo/{fooId}',
+        responses: {
+            200: { contentType: 'application/json' }
+        }
+    })
+    async update(
+        @PathParam('fooId', { schema: { type: 'string' } })
+        fooId: string,
+        @BodyParam('bar', { schema: { type: 'string' }})
+        bar: string
+    ) {
+        return { fooId, bar };
     }
 }

--- a/src/test/specs/router.test.ts
+++ b/src/test/specs/router.test.ts
@@ -186,6 +186,17 @@ describe('Router', () => {
             assert.deepEqual(res.body, { fooId: 123 });
         });
 
+        it('PUT /foo/{fooId}', async () => {
+            const request = supertest(app.callback());
+            const res = await request.put('/foo/123')
+                .send({ bar: 'hello' });
+            assert.equal(res.status, 200);
+            assert.equal(res.header['foo-before-all'], 'true');
+            assert.equal(res.header['foo-before-get-one'], '123');
+            assert(res.header['bar-before-all'] == null);
+            assert.deepEqual(res.body, { fooId: 123, bar: 'hello' });
+        });
+
         it('GET /bar with default parameters', async () => {
             const request = supertest(app.callback());
             const res = await request.get('/bar');


### PR DESCRIPTION
I would like to have both flavours for declaring request bodies supported: type system-friendly and entity-friendly.

It does make sense, however, to constrain each endpoint definition to only one option (hence the check inside).

Please note that assembling request body schema for Open API from body params definitions is not yet implemented, because we don't yet use Open API. There's a TODO item about that in this PR.