### PR TITLE
Optional timestamp for counter metrics

### DIFF
--- a/src/main/metrics/counter.ts
+++ b/src/main/metrics/counter.ts
@@ -12,7 +12,7 @@ export class CounterMetric extends Metric {
         return this.data.get(createLabelsKey(labels));
     }
 
-    incr(value: number = 1, labels: MetricLabels = {}, timestamp: number = Date.now()) {
+    incr(value: number = 1, labels: MetricLabels = {}, timestamp?: number) {
         const key = createLabelsKey(labels);
         const datum = this.data.get(key);
         if (datum) {
@@ -33,7 +33,7 @@ export class CounterMetric extends Metric {
                 this.getMetricLineName(datum.labels),
                 datum.value,
                 datum.timestamp,
-            ].join(' ');
+            ].filter(x => x != null).join(' ');
         }
     }
 

--- a/src/main/metrics/registry.ts
+++ b/src/main/metrics/registry.ts
@@ -21,8 +21,8 @@ export class MetricsRegistry {
         return gauge;
     }
 
-    histogram(name: string, help: string) {
-        const histogram = new HistogramMetric(name, help);
+    histogram(name: string, help: string, buckets?: number[]) {
+        const histogram = new HistogramMetric(name, help, buckets);
         this.register(histogram);
         return histogram;
     }

--- a/src/main/metrics/util.ts
+++ b/src/main/metrics/util.ts
@@ -4,7 +4,7 @@ export interface MetricLabels {
 
 export interface MetricDatum {
     labels: MetricLabels;
-    timestamp: number;
+    timestamp?: number;
     value: number;
 }
 

--- a/src/test/specs/metrics.test.ts
+++ b/src/test/specs/metrics.test.ts
@@ -32,14 +32,14 @@ describe('CounterMetric', () => {
         const counter = new CounterMetric('foo', 'Foo help');
         counter.incr(1, {}, 123123123);
         counter.incr(1, { lbl: 'one' }, 123123123);
-        counter.incr(2, { lbl: 'two' }, 123123123);
+        counter.incr(2, { lbl: 'two' });
         counter.incr(3, { lbl: 'three', foo: '1' }, 123123123);
         assert.equal(counter.report().trim(), `
 # HELP foo Foo help
 # TYPE foo counter
 foo 1 123123123
 foo{lbl="one"} 1 123123123
-foo{lbl="two"} 2 123123123
+foo{lbl="two"} 2
 foo{foo="1",lbl="three"} 3 123123123
         `.trim());
     });


### PR DESCRIPTION
This PR addresses issue with rarely updated counters by removing default timestamp from reports, which effectively changes it from 'time of last increment' to 'time of report', thus it eliminates 'null' (not signal) values and allows us to `sum` counters between different instances even if they have not incremented their counters at the same tme.

For gauges we still need 'time of measurement' instead of 'time of report fetched', so I've applied this updated logic to counters only.

* Also it adds ability to specify custom buckets for histogram metrics.

---
Example of problematic metrics:
![image](https://user-images.githubusercontent.com/14026/76755216-66b50880-677b-11ea-9476-d0adc336c74d.png)

